### PR TITLE
Fixed overlapping of search input when combined with other extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0] - 2024-12-13
+### Fixed
+- Fixed an result display issue when extension was combined with `@shopgate-project/persistent-search-bar` and `@shopgate-project/configurable-banner`
+
 ## [1.2.5] - 2023-01-10
 ### Added
 - Added filters to support filtered search preview

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.5",
+  "version": "1.3.0-beta.1",
   "id": "@shopgate-project/search-suggestions-extended",
   "configuration": {
     "layout": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0",
   "id": "@shopgate-project/search-suggestions-extended",
   "configuration": {
     "layout": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2145,11 +2145,6 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/frontend/portals/SearchSuggestions/components/Result/index.jsx
+++ b/frontend/portals/SearchSuggestions/components/Result/index.jsx
@@ -4,12 +4,14 @@ import {
   getCurrentRouteHelper, useTheme, RouteContext, ITEMS_PER_LOAD, UIEvents,
 } from '@shopgate/engage/core';
 import { ViewContext } from '@shopgate/engage/components/View';
-import { themeConfig } from '@shopgate/pwa-common/helpers/config';
 import { ResultContext } from '../Provider/context';
 
 const styles = {
   products: css({
-    marginTop: themeConfig.variables.gap.small,
+    '&& [data-test-id="productGrid"]': {
+      marginTop: 0,
+      paddingTop: 16,
+    },
   }),
 };
 

--- a/frontend/portals/SearchSuggestions/index.jsx
+++ b/frontend/portals/SearchSuggestions/index.jsx
@@ -25,8 +25,11 @@ const baseStyle = {
 
 /** Styles for different portals */
 const styles = {
-  [`persistent-search-bar.${SEARCH_SUGGESTIONS}`]: css(baseStyle, {
-    top: `calc(var(--safe-area-inset-top) + 56px + ${appBarHeight}px)`,
+  [`persistent-search-bar.${SEARCH_SUGGESTIONS}`]: css({
+    position: 'relative',
+    top: 0,
+    height: '100%',
+    overflowY: 'scroll',
   }),
   [SEARCH_SUGGESTIONS]: css(baseStyle, {
     top: `calc(var(--safe-area-inset-top) + ${appBarHeight}px)`,


### PR DESCRIPTION
This pull request fixes an issue where `extended-search-results` inside `persistent-search-bar` results overlapped the search input when `configurable-banner` extension is deployed.